### PR TITLE
Update ESLint plugin to version 1.2.0 across project templates

### DIFF
--- a/apps/astro/package.json
+++ b/apps/astro/package.json
@@ -31,7 +31,7 @@
     "@astrojs/check": "^0.9.4",
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0",
-    "@nextnode/eslint-plugin": "^1.1.0",
+    "@nextnode/eslint-plugin": "^1.2.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@vitest/coverage-istanbul": "^3.2.4",
     "@vitest/coverage-v8": "^3.1.4",

--- a/apps/astro/pnpm-lock.yaml
+++ b/apps/astro/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^19.1.0
         version: 19.8.1
       '@nextnode/eslint-plugin':
-        specifier: ^1.1.0
-        version: 1.1.0(@typescript-eslint/utils@8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.5.1))
+        specifier: ^1.2.0
+        version: 1.2.0(@typescript-eslint/utils@8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.5.1))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -687,8 +687,8 @@ packages:
   '@next/eslint-plugin-next@15.4.4':
     resolution: {integrity: sha512-1FDsyN//ai3Jd97SEd7scw5h1yLdzDACGOPRofr2GD3sEFsBylEEoL0MHSerd4n2dq9Zm/mFMqi4+NRMOreOKA==}
 
-  '@nextnode/eslint-plugin@1.1.0':
-    resolution: {integrity: sha512-vFfyjdvZQ9OJlDEWe7wI+egIpc7FbelqQDkpcjRp2EG2b1OXCtYGAZBOO474IbrRJpB0r6VuoTA0M0gmFEWGBg==}
+  '@nextnode/eslint-plugin@1.2.0':
+    resolution: {integrity: sha512-aXwB0+aHPr2iWKpvj/bXsBKnl4OrW9S0C9YCTQXsPsw9jbOBaYlqgTr9QMIpQK/4gKyS1nO+iQcaEr7XF50NhA==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       eslint: ^9.22.0
@@ -4829,7 +4829,7 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@nextnode/eslint-plugin@1.1.0(@typescript-eslint/utils@8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.5.1))':
+  '@nextnode/eslint-plugin@1.2.0(@typescript-eslint/utils@8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.5.1))':
     dependencies:
       '@eslint/js': 9.31.0
       '@next/eslint-plugin-next': 15.4.4

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -34,7 +34,7 @@
     "@changesets/cli": "^2.29.4",
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0",
-    "@nextnode/eslint-plugin": "^1.1.0",
+    "@nextnode/eslint-plugin": "^1.2.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@vitest/coverage-v8": "^3.1.4",

--- a/packages/library/pnpm-lock.yaml
+++ b/packages/library/pnpm-lock.yaml
@@ -19,22 +19,25 @@ importers:
         version: 2.29.4
       '@commitlint/cli':
         specifier: ^19.2.1
-        version: 19.8.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 19.8.1(@types/node@22.17.2)(typescript@5.8.3)
       '@commitlint/config-conventional':
         specifier: ^19.1.0
         version: 19.8.1
       '@nextnode/eslint-plugin':
-        specifier: ^1.1.0
-        version: 1.1.0(eslint@9.27.0(jiti@2.4.2))
+        specifier: ^1.2.0
+        version: 1.2.0(eslint@9.27.0(jiti@2.4.2))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.17.2
       '@vitest/coverage-v8':
         specifier: ^3.1.4
-        version: 3.1.4(vitest@3.1.4(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0))
+        version: 3.1.4(vitest@3.1.4(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0))
       better-sort-package-json:
         specifier: ^1.1.1
         version: 1.1.1
@@ -52,7 +55,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.1.4(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0)
+        version: 3.1.4(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0)
 
 packages:
 
@@ -82,6 +85,10 @@ packages:
 
   '@babel/runtime@7.27.3':
     resolution: {integrity: sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.3':
+    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.3':
@@ -530,8 +537,8 @@ packages:
   '@next/eslint-plugin-next@15.3.2':
     resolution: {integrity: sha512-ijVRTXBgnHT33aWnDtmlG+LJD+5vhc9AKTJPquGG5NKXjpKNjc62woIhFtrAcWdBobt8kqjCoaJ0q6sDQoX7aQ==}
 
-  '@nextnode/eslint-plugin@1.1.0':
-    resolution: {integrity: sha512-vFfyjdvZQ9OJlDEWe7wI+egIpc7FbelqQDkpcjRp2EG2b1OXCtYGAZBOO474IbrRJpB0r6VuoTA0M0gmFEWGBg==}
+  '@nextnode/eslint-plugin@1.2.0':
+    resolution: {integrity: sha512-aXwB0+aHPr2iWKpvj/bXsBKnl4OrW9S0C9YCTQXsPsw9jbOBaYlqgTr9QMIpQK/4gKyS1nO+iQcaEr7XF50NhA==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       eslint: ^9.22.0
@@ -703,8 +710,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.15.21':
-    resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
+  '@types/node@22.17.2':
+    resolution: {integrity: sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==}
 
   '@typescript-eslint/eslint-plugin@8.33.0':
     resolution: {integrity: sha512-CACyQuqSHt7ma3Ns601xykeBK/rDeZa3w6IS6UtMQbixO5DWy+8TilKkviGDH6jtWCo8FGRKEK5cLLkPvEammQ==}
@@ -2769,6 +2776,8 @@ snapshots:
 
   '@babel/runtime@7.27.3': {}
 
+  '@babel/runtime@7.28.3': {}
+
   '@babel/types@7.27.3':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
@@ -2968,11 +2977,11 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@commitlint/cli@19.8.1(@types/node@22.15.21)(typescript@5.8.3)':
+  '@commitlint/cli@19.8.1(@types/node@22.17.2)(typescript@5.8.3)':
     dependencies:
       '@commitlint/format': 19.8.1
       '@commitlint/lint': 19.8.1
-      '@commitlint/load': 19.8.1(@types/node@22.15.21)(typescript@5.8.3)
+      '@commitlint/load': 19.8.1(@types/node@22.17.2)(typescript@5.8.3)
       '@commitlint/read': 19.8.1
       '@commitlint/types': 19.8.1
       tinyexec: 1.0.1
@@ -3019,7 +3028,7 @@ snapshots:
       '@commitlint/rules': 19.8.1
       '@commitlint/types': 19.8.1
 
-  '@commitlint/load@19.8.1(@types/node@22.15.21)(typescript@5.8.3)':
+  '@commitlint/load@19.8.1(@types/node@22.17.2)(typescript@5.8.3)':
     dependencies:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/execute-rule': 19.8.1
@@ -3027,7 +3036,7 @@ snapshots:
       '@commitlint/types': 19.8.1
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.15.21)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.17.2)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -3281,7 +3290,7 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@nextnode/eslint-plugin@1.1.0(eslint@9.27.0(jiti@2.4.2))':
+  '@nextnode/eslint-plugin@1.2.0(eslint@9.27.0(jiti@2.4.2))':
     dependencies:
       '@eslint/js': 9.27.0
       '@next/eslint-plugin-next': 15.3.2
@@ -3381,7 +3390,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.27.3
+      '@babel/runtime': 7.28.3
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -3415,7 +3424,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.2
 
   '@types/eslint@9.6.1':
     dependencies:
@@ -3432,7 +3441,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.15.21':
+  '@types/node@22.17.2':
     dependencies:
       undici-types: 6.21.0
 
@@ -3581,7 +3590,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.7.2':
     optional: true
 
-  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0))':
+  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3595,7 +3604,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0)
+      vitest: 3.1.4(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3606,13 +3615,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0))':
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -3880,9 +3889,9 @@ snapshots:
       meow: 12.1.1
       split2: 4.2.0
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.15.21)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@22.17.2)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.2
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.4.2
       typescript: 5.8.3
@@ -5541,13 +5550,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.1.4(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0):
+  vite-node@3.1.4(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5562,7 +5571,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0):
+  vite@6.3.5(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
@@ -5571,15 +5580,15 @@ snapshots:
       rollup: 4.41.1
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.2
       fsevents: 2.3.3
       jiti: 2.4.2
       yaml: 2.8.0
 
-  vitest@3.1.4(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0):
+  vitest@3.1.4(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0))
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -5596,11 +5605,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0)
-      vite-node: 3.1.4(@types/node@22.15.21)(jiti@2.4.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0)
+      vite-node: 3.1.4(@types/node@22.17.2)(jiti@2.4.2)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.2
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary
This PR updates the `@nextnode/eslint-plugin` dependency from version 1.1.0 to 1.2.0 across both the Astro app template and library package template.

## Changes
**Dependency Updates:**
- Bumped `@nextnode/eslint-plugin` from `^1.1.0` to `^1.2.0` in:
  - `apps/astro/package.json` and corresponding lock file
  - `packages/library/package.json` and corresponding lock file
- Updated lock file entries to reflect the new package version and integrity hashes
- Minor Node.js type definitions update from `22.15.21` to `22.17.2` in the library package

**Impact:**
- All project templates now use the latest version of the NextNode ESLint plugin
- Maintains consistency across the template ecosystem
- No breaking changes as this is a minor version bump

---
🤖 Generated with gprc made by Walid + Claude