### PR TITLE
fix: use .js extension in library template test imports

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -58,6 +58,11 @@
   },
   "packageManager": "pnpm@10.11.0",
   "type": "module",
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "dist/**/*"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/library/src/formatting/date.spec.ts
+++ b/packages/library/src/formatting/date.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { formatDate } from './date'
+import { formatDate } from './date.js'
 
 describe('formatDate', () => {
 	it('should format a date with default options', () => {


### PR DESCRIPTION
## Summary
This PR includes changes across 3 files.

## Changes
 3 files changed, 55 insertions(+), 1 deletion(-)

### Recent Commits
- 32494fa fix: use .js extension in library template test imports
- b999401 fix: add files field to library template package.json

### Files Modified
- A	.claude/settings.json
- M	packages/library/package.json
- M	packages/library/src/formatting/date.spec.ts

---
🤖 Generated with gprc made by Walid + Claude